### PR TITLE
Add labels for a100spot instances, update retro img

### DIFF
--- a/chart/values-azure.yaml
+++ b/chart/values-azure.yaml
@@ -49,7 +49,7 @@ storageClass:
   defaultClass: true
 
 commonImg: &commonImg "us-docker.pkg.dev/dara-c1b52/cloudbuild/gooey-gpu/common@sha256:43ce3db1869b8eb151989270a7dfe4f9a68ee887fa5d86ca0d238e185b4e96c1"
-retroImg: &retroImg "us-docker.pkg.dev/dara-c1b52/cloudbuild/gooey-gpu/retro@sha256:16b0cd846bff171b2a087f6409658c08748bbdf7e308474820c7a6e96eef8695"
+retroImg: &retroImg "us-docker.pkg.dev/dara-c1b52/cloudbuild/gooey-gpu/retro@sha256:85053077c29f4a3f4edc724924f4bebf736402872810ee3d6d430272430b6032"
 deforumImg: &deforumImg "us-docker.pkg.dev/dara-c1b52/cloudbuild/gooey-gpu-dev/deforum_sd@sha256:fefdf0b01f6894aa6943c5afe7022b44e109f64c241512ca268b7d173d985a01"
 
 controlnetModelIds: &controlnetModelIds |-

--- a/chart/values-azure.yaml
+++ b/chart/values-azure.yaml
@@ -70,7 +70,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -94,7 +95,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -118,7 +120,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -139,7 +142,8 @@ deployments:
     image: *deforumImg
     replicas: 2
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -158,7 +162,8 @@ deployments:
     image: *deforumImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -177,7 +182,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -197,7 +203,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -217,7 +224,8 @@ deployments:
     image: *retroImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -237,7 +245,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -261,7 +270,8 @@ deployments:
     image: "us-docker.pkg.dev/dara-c1b52/cloudbuild/gooey-gpu/common@sha256:5fb0ffa128cbdda86747fedf5ef68e9df8256735d8535149c6fffa41a3749883"
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -281,7 +291,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -300,7 +311,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -319,7 +331,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -340,7 +353,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -361,7 +375,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -382,7 +397,8 @@ deployments:
     image: *commonImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -406,7 +422,8 @@ deployments:
     image: *retroImg
     replicas: 3
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"
@@ -425,7 +442,8 @@ deployments:
     image: *retroImg
     replicas: 1
     nodeSelector:
-      agentpool: "a100spot"
+      gpuEnabled: "true"
+      gpuType: "a100"
     tolerations:
       - key: "kubernetes.azure.com/scalesetpriority"
         operator: "Equal"


### PR DESCRIPTION
- Add labels instead of agentpool for a100 spot node selector
- Update retro img for azure cluster
